### PR TITLE
Feat: 스터디 참가 기능에 비관적 락 구현

### DIFF
--- a/src/main/java/com/pomodoro/pomodoromate/common/annotations/LockTimeout.java
+++ b/src/main/java/com/pomodoro/pomodoromate/common/annotations/LockTimeout.java
@@ -1,0 +1,14 @@
+package com.pomodoro.pomodoromate.common.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LockTimeout {
+    int timeout() default 5000;
+}

--- a/src/main/java/com/pomodoro/pomodoromate/common/aspects/LockTimeoutAspect.java
+++ b/src/main/java/com/pomodoro/pomodoromate/common/aspects/LockTimeoutAspect.java
@@ -1,0 +1,24 @@
+package com.pomodoro.pomodoromate.common.aspects;
+
+import com.pomodoro.pomodoromate.common.repositories.LockTimeoutRepository;
+import com.pomodoro.pomodoromate.common.annotations.LockTimeout;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LockTimeoutAspect {
+    private final LockTimeoutRepository lockTimeoutRepository;
+
+    @Before("@annotation(com.pomodoro.pomodoromate.common.annotations.LockTimeout)")
+    public void beforeLockTimeout(JoinPoint joinPoint) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        LockTimeout lockTimeout = methodSignature.getMethod().getAnnotation(LockTimeout.class);
+        lockTimeoutRepository.setLockTimeout(lockTimeout.timeout());
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/common/repositories/LockTimeoutRepository.java
+++ b/src/main/java/com/pomodoro/pomodoromate/common/repositories/LockTimeoutRepository.java
@@ -1,0 +1,19 @@
+package com.pomodoro.pomodoromate.common.repositories;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LockTimeoutRepository {
+    private final EntityManager entityManager;
+
+    public LockTimeoutRepository(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public void setLockTimeout(int timeout) {
+        Query query = entityManager.createNativeQuery("SET lock_timeout = " + timeout);
+        query.executeUpdate();
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipateService.java
+++ b/src/main/java/com/pomodoro/pomodoromate/participant/applications/ParticipateService.java
@@ -11,6 +11,7 @@ import com.pomodoro.pomodoromate.user.models.User;
 import com.pomodoro.pomodoromate.user.models.UserId;
 import com.pomodoro.pomodoromate.user.repositories.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -28,12 +29,12 @@ public class ParticipateService {
         this.studyRoomRepository = studyRoomRepository;
     }
 
-    // @Transactional
-    public synchronized Long participate(UserId userId, StudyRoomId studyRoomId) {
+    @Transactional
+    public Long participate(UserId userId, StudyRoomId studyRoomId) {
         User user = userRepository.findById(userId.value())
                 .orElseThrow(UnauthorizedException::new);
 
-        StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId.value())
+        StudyRoom studyRoom = studyRoomRepository.findByIdForUpdate(studyRoomId.value())
                 .orElseThrow(StudyRoomNotFoundException::new);
 
         studyRoom.validateIncomplete();

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepositoryImpl.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepositoryImpl.java
@@ -5,18 +5,21 @@ import com.pomodoro.pomodoromate.participant.models.QParticipant;
 import com.pomodoro.pomodoromate.studyRoom.dtos.StudyRoomSummaryDto;
 import com.pomodoro.pomodoromate.studyRoom.models.QStudyRoom;
 import com.pomodoro.pomodoromate.studyRoom.models.Step;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class StudyRoomRepositoryImpl implements StudyRoomRepositoryQueryDsl {
@@ -48,6 +51,19 @@ public class StudyRoomRepositoryImpl implements StudyRoomRepositoryQueryDsl {
         Long count = getPageCount(studyRoom);
 
         return new PageImpl<>(studyRooms, pageable, count);
+    }
+
+    @Override
+    public Optional<StudyRoom> findByIdForUpdate(Long id) {
+        QStudyRoom studyRoom = QStudyRoom.studyRoom;
+
+        return Optional.ofNullable(
+                queryFactory
+                        .select(studyRoom)
+                        .from(studyRoom)
+                        .where(studyRoom.id.eq(id))
+                        .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                        .fetchOne());
     }
 
     private Expression<Long> getActiveParticipantCount(QStudyRoom studyRoom) {

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepositoryImpl.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepositoryImpl.java
@@ -6,7 +6,6 @@ import com.pomodoro.pomodoromate.studyRoom.dtos.StudyRoomSummaryDto;
 import com.pomodoro.pomodoromate.studyRoom.models.QStudyRoom;
 import com.pomodoro.pomodoromate.studyRoom.models.Step;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
-import com.pomodoro.pomodoromate.studyRoom.models.StudyRoomId;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepositoryQueryDsl.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepositoryQueryDsl.java
@@ -1,5 +1,6 @@
 package com.pomodoro.pomodoromate.studyRoom.repositories;
 
+import com.pomodoro.pomodoromate.common.annotations.LockTimeout;
 import com.pomodoro.pomodoromate.studyRoom.dtos.StudyRoomSummaryDto;
 import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
 import org.springframework.data.domain.Page;
@@ -10,5 +11,6 @@ import java.util.Optional;
 public interface StudyRoomRepositoryQueryDsl {
     Page<StudyRoomSummaryDto> findAllSummaryDto(Pageable pageable);
 
+    @LockTimeout
     Optional<StudyRoom> findByIdForUpdate(Long id);
 }

--- a/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepositoryQueryDsl.java
+++ b/src/main/java/com/pomodoro/pomodoromate/studyRoom/repositories/StudyRoomRepositoryQueryDsl.java
@@ -1,9 +1,14 @@
 package com.pomodoro.pomodoromate.studyRoom.repositories;
 
 import com.pomodoro.pomodoromate.studyRoom.dtos.StudyRoomSummaryDto;
+import com.pomodoro.pomodoromate.studyRoom.models.StudyRoom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface StudyRoomRepositoryQueryDsl {
     Page<StudyRoomSummaryDto> findAllSummaryDto(Pageable pageable);
+
+    Optional<StudyRoom> findByIdForUpdate(Long id);
 }

--- a/src/test/java/com/pomodoro/pomodoromate/participant/applications/ParticipateServiceIntegrationTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/participant/applications/ParticipateServiceIntegrationTest.java
@@ -35,11 +35,11 @@ class ParticipateServiceIntegrationTest {
 
     @Test
     void participateConcurrentVerification() throws InterruptedException {
-        int requestCount = 5;
+        int requestCount = 100;
 
         StudyRoom studyRoom = StudyRoom.builder()
                 .id(1000L)
-                .maxParticipantCount(MaxParticipantCount.of(3))
+                .maxParticipantCount(MaxParticipantCount.of(8))
                 .build();
 
         studyRoomRepository.save(studyRoom);
@@ -52,7 +52,7 @@ class ParticipateServiceIntegrationTest {
             userRepository.save(user);
         }
 
-        int threadCount = 5;
+        int threadCount = 30;
 
         // thread 사용할 수 있는 서비스 선언, 몇 개의 스레드 사용할건지 지정
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
@@ -77,6 +77,6 @@ class ParticipateServiceIntegrationTest {
 
         Long participantCount = participantRepository.countActiveBy(studyRoom.id());
 
-        assertThat(participantCount).isEqualTo(3L);
+        assertThat(participantCount).isEqualTo(8L);
     }
 }

--- a/src/test/java/com/pomodoro/pomodoromate/participant/applications/ParticipateServiceTest.java
+++ b/src/test/java/com/pomodoro/pomodoromate/participant/applications/ParticipateServiceTest.java
@@ -62,7 +62,7 @@ class ParticipateServiceTest {
         given(userRepository.findById(user.id().value()))
                 .willReturn(Optional.of(user));
 
-        given(studyRoomRepository.findById(studyRoom.id().value()))
+        given(studyRoomRepository.findByIdForUpdate(studyRoom.id().value()))
                 .willReturn(Optional.of(studyRoom));
 
         given(participantRepository.countActiveBy(studyRoom.id()))
@@ -100,7 +100,7 @@ class ParticipateServiceTest {
         given(userRepository.findById(user.id().value()))
                 .willReturn(Optional.of(user));
 
-        given(studyRoomRepository.findById(invalidStudyRoomId.value()))
+        given(studyRoomRepository.findByIdForUpdate(invalidStudyRoomId.value()))
                 .willThrow(StudyRoomNotFoundException.class);
 
         assertThrows(StudyRoomNotFoundException.class,
@@ -128,7 +128,7 @@ class ParticipateServiceTest {
         given(userRepository.findById(user.id().value()))
                 .willReturn(Optional.of(user));
 
-        given(studyRoomRepository.findById(studyRoom.id().value()))
+        given(studyRoomRepository.findByIdForUpdate(studyRoom.id().value()))
                 .willReturn(Optional.of(studyRoom));
 
         given(participantRepository.countActiveBy(studyRoom.id()))
@@ -152,7 +152,7 @@ class ParticipateServiceTest {
         given(userRepository.findById(user.id().value()))
                 .willReturn(Optional.of(user));
 
-        given(studyRoomRepository.findById(studyRoom.id().value()))
+        given(studyRoomRepository.findByIdForUpdate(studyRoom.id().value()))
                 .willReturn(Optional.of(studyRoom));
 
         given(participantRepository.countActiveBy(studyRoom.id()))


### PR DESCRIPTION
- 스터디 참가 기능 동시성 제어 방법 변경(synchronized -> 비관적 락)
  - 이유: @Transactional 사용과 여러 대의 서버일 경우, 동시성을 보장하기 위해서
  
- 실제 웹 환경에서 스터디 참가 기능이 안되는 이슈 해결
  - 원인: synchronized 사용을 위해 @Transactional을 지웠는데 save를 따로 진행하지 않아서 db에 반영이 안됨
  - 해결: save 로직 작성 -> 비관적 락으로 변경 후 @Transactional 사용
  
- Lock Timeout 설정
  - 비관적 락 사용 시, 무한정 대기를 방지하기 위해 lock timeout 설정이 필요함
  - postgreSQL은 default로 무한정 대기하기 때문에 꼭 필요
  - Jpa에서는 queryHints로 lock timeout 설정이 가능하지만 postgreSQL은 지원하지 않음
  - -> locktimeout을 사용하는 경우가 많을 것 같으니, aop를 활용하여 lock timeout annotation 생성