### PR TITLE
Feat: Logback 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	// Logback
+	implementation 'ca.pjer:logback-awslogs-appender:1.6.0'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/src/main/java/com/pomodoro/pomodoromate/common/advices/ExceptionAdvice.java
+++ b/src/main/java/com/pomodoro/pomodoromate/common/advices/ExceptionAdvice.java
@@ -2,15 +2,21 @@ package com.pomodoro.pomodoromate.common.advices;
 
 import com.pomodoro.pomodoromate.common.exceptions.CustomizedException;
 import com.pomodoro.pomodoromate.common.exceptions.ExceptionResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j(topic = "ExceptionLogger")
 @RestControllerAdvice
 public class ExceptionAdvice {
 
     @ExceptionHandler(CustomizedException.class)
     public ResponseEntity<ExceptionResponse> customizedException(CustomizedException exception) {
+        log.error("Error occurred: statusCode={}, message={}, stackTrace={}",
+                exception.statusCode(),
+                exception.message(),
+                exception);
         return new ResponseEntity<>(ExceptionResponse.of(exception.message()), exception.statusCode());
     }
 }

--- a/src/main/java/com/pomodoro/pomodoromate/common/dtos/HttpLogMessage.java
+++ b/src/main/java/com/pomodoro/pomodoromate/common/dtos/HttpLogMessage.java
@@ -1,0 +1,58 @@
+package com.pomodoro.pomodoromate.common.dtos;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Builder;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+
+
+@Builder
+public record HttpLogMessage(
+        ContentCachingRequestWrapper request,
+        ContentCachingResponseWrapper response,
+        long elapsedTime,
+        ObjectMapper objectMapper
+) {
+    private static final String HTTP_LOG_FORMAT = """
+                    
+            Request:
+                RequestURI: %s %s
+                QueryString: %s
+                Authorization: %s
+                Body: %s
+            ================
+            Response:
+                StatusCode: %d
+                Body: %s
+                ElapsedTime: %d ms
+                    """;
+
+    public String toFormattedLog() throws IOException {
+        String requestBody = new String(request.getContentAsByteArray(), request.getCharacterEncoding());
+        String responseBody = new String(response.getContentAsByteArray(), response.getCharacterEncoding());
+
+        return String.format(
+                HTTP_LOG_FORMAT,
+                request.getMethod(),
+                request.getRequestURI(),
+                request.getQueryString(),
+                request.getHeader("Authorization"),
+                formatJson(requestBody),
+
+                response.getStatus(),
+                formatJson(responseBody),
+                elapsedTime
+        );
+    }
+
+    private String formatJson(String jsonString) throws IOException {
+        if (jsonString == null || jsonString.isBlank()) {
+            return "";
+        }
+
+        Object jsonObject = objectMapper.readValue(jsonString, Object.class);
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
+    }
+}

--- a/src/main/java/com/pomodoro/pomodoromate/common/filters/HttpLoggingFilter.java
+++ b/src/main/java/com/pomodoro/pomodoromate/common/filters/HttpLoggingFilter.java
@@ -1,0 +1,60 @@
+package com.pomodoro.pomodoromate.common.filters;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pomodoro.pomodoromate.common.dtos.HttpLogMessage;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j(topic = "HttpLogger")
+public class HttpLoggingFilter extends OncePerRequestFilter {
+    private static final String REQUEST_ID = "request_id";
+
+    private final ObjectMapper objectMapper;
+
+    public HttpLoggingFilter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String requestId = UUID.randomUUID().toString().substring(0, 8);
+        MDC.put(REQUEST_ID, requestId);
+
+        ContentCachingRequestWrapper cachingRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper cachingResponse = new ContentCachingResponseWrapper(response);
+
+        long startTime = System.currentTimeMillis();
+        filterChain.doFilter(cachingRequest, cachingResponse);
+        long endTime = System.currentTimeMillis();
+
+        try {
+            log.info(
+                    HttpLogMessage.builder()
+                            .request(cachingRequest)
+                            .response(cachingResponse)
+                            .elapsedTime(endTime - startTime)
+                            .objectMapper(objectMapper)
+                            .build()
+                            .toFormattedLog()
+            );
+
+            cachingResponse.copyBodyToResponse();
+        } catch (Exception exception) {
+            log.error("[{}] Logging 실패", this.getClass().getSimpleName(), exception);
+        }
+
+        MDC.clear();
+    }
+}

--- a/src/main/resources/cloudwatch-appender.xml
+++ b/src/main/resources/cloudwatch-appender.xml
@@ -1,0 +1,19 @@
+<included>
+    <appender name="CLOUDWATCH" class="ca.pjer.logback.AwsLogsAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <layout>
+            <pattern>[%thread] [%date] [%level] [%file:%line] - %msg%n</pattern>
+        </layout>
+        <logGroupName>pomodoro-log-group</logGroupName>
+        <logStreamUuidPrefix>pomodoro-log</logStreamUuidPrefix>
+        <logRegion>ap-northeast-2</logRegion>
+        <maxBatchLogEvents>50</maxBatchLogEvents>
+        <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+        <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+        <retentionTimeDays>5</retentionTimeDays>
+        <accessKeyId>${AWS_ACCESS_KEY}</accessKeyId>
+        <secretAccessKey>${AWS_SECRET_KEY}</secretAccessKey>
+    </appender>
+</included>

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/default-appdender.xml
+++ b/src/main/resources/default-appdender.xml
@@ -1,0 +1,18 @@
+<included>
+    <appender name="DEFAULT" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/default/default.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>20MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/error-appender.xml
+++ b/src/main/resources/error-appender.xml
@@ -1,0 +1,18 @@
+<included>
+    <appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/warn-error/warn-error.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>5MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>20MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/http-appender.xml
+++ b/src/main/resources/http-appender.xml
@@ -1,0 +1,20 @@
+<included>
+    <appender name="HTTP" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/http/http.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>20MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty name="AWS_ACCESS_KEY" source="cloud.aws.credentials.accessKey"/>
+    <springProperty name="AWS_SECRET_KEY" source="cloud.aws.credentials.secretKey"/>
+
+    <property name="LOG_PATH" value="./logs"/>
+
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%green(%d{yyyy-MM-dd HH:mm:ss.SSS, ${logback.timezone:-Asia/Seoul}}) %magenta([%thread]) [%X{request_id}] %clr(%5level) %cyan(%logger) - %yellow(%msg%n)"/>
+    <property name="FILE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS, ${logback.timezone:-Asia/Seoul}} [%thread] [%X{request_id}] %5level %logger - %msg%n"/>
+
+    <include resource="console-appender.xml"/>
+    <include resource="default-appender.xml"/>
+    <include resource="http-appender.xml"/>
+    <include resource="error-appender.xml"/>
+    <include resource="cloudwatch-appender.xml"/>
+
+    <springProfile name="production">
+        <root level="INFO">
+            <appender-ref ref="DEFAULT"/>
+            <appender-ref ref="CLOUDWATCH"/>
+        </root>
+        
+        <logger name="ExceptionLogger" level="WARN" additivity="false">
+            <appender-ref ref="ERROR"/>
+        </logger>
+
+        <logger name="HttpLogger" level="INFO" additivity="false">
+            <appender-ref ref="HTTP"/>
+        </logger>
+    </springProfile>
+
+    <springProfile name="default">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
#### 1. Logback 설정
- CLOUDWATCH 어펜더: CloudWatch에 로그 전송
- CONSOLE 어펜더: 콘솔에 로그 출력
- DEFAULT 어펜더, ERROR 어펜더: 파일로 로그 저장
- HTTP 어펜더: HTTP 요청 및 응답 로그를 별도의 파일에 저장

#### 2. Spring Profile별 로깅 설정
- production 프로필:
  - 루트 로그 레벨을 INFO로 설정하고, DEFAULT 및 CLOUDWATCH 어펜더 사용
  - ExceptionLogger의 로그 레벨을 WARN으로 설정하고, ERROR 어펜더 사용
  - HttpLogger의 로그 레벨을 INFO로 설정하고, HTTP 어펜더 사용
- default 프로필:
  - 루트 로그 레벨을 INFO로 설정하고, CONSOLE 어펜더 사용
  
####  3. HttpLoggingFilter 클래스 추가
 - HTTP 요청과 응답을 로깅하기 위한 필터
 - 멀티스레드 환경에서 동일한 요청을 구별하기 위해 각 요청마다 고유한 request_id 생성
 
 